### PR TITLE
Fix issue #5 - change tool repo

### DIFF
--- a/phpcq-plugin.json
+++ b/phpcq-plugin.json
@@ -14,7 +14,7 @@
         "sources": [
           {
             "type": "github",
-            "repository": "squizlabs/PHP_CodeSniffer"
+            "repository": "PHPCSStandards/PHP_CodeSniffer"
           }
         ]
       },
@@ -23,7 +23,7 @@
         "sources": [
           {
             "type": "github",
-            "repository": "squizlabs/PHP_CodeSniffer"
+            "repository": "PHPCSStandards/PHP_CodeSniffer"
           }
         ]
       }


### PR DESCRIPTION
We now use `PHPCSStandards/PHP_CodeSniffer` instead of the unmaintained `PHPCSStandards/PHP_CodeSniffer`.

Our supported releases 2.x and 3.x are contained in both repositories, therefore no other change is needed.