### PR TITLE
Fix phpcs URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # phpcs/phpcbf plugin for phpcq.
 
-This plugin provides [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) integration for phpcq.
+This plugin provides [phpcs](https://github.com/PHPCSStandards/PHP_CodeSniffer/) integration for phpcq.
 
-It also provides a "fix" option, which runs [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) on the code base.
+It also provides a "fix" option, which runs [phpcbf](https://github.com/PHPCSStandards/PHP_CodeSniffer/) on the code base.
 
 ## Configuration
 


### PR DESCRIPTION
The repository has moved to [PHPCSStandards/PHP_CodeSniffer/](https://github.com/PHPCSStandards/PHP_CodeSniffer/)